### PR TITLE
Fix pack step to target library project

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Pack
         run: |
-          dotnet pack -c Release -o artifacts \
+          dotnet pack src/Liaison.Mediator/Liaison.Mediator.csproj \
+            -c Release \
+            -o artifacts \
             -p:PackageVersion=${{ env.PKG_VERSION }} \
             -p:IncludeSymbols=true \
             -p:SymbolPackageFormat=snupkg


### PR DESCRIPTION
## Summary
- update the publish workflow to run dotnet pack against the library project explicitly

## Testing
- dotnet pack src/Liaison.Mediator/Liaison.Mediator.csproj -c Release -o artifacts/test -p:PackageVersion=0.1.0 -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911150749708327bff14456b11da978)