### PR TITLE
Add runnable usage samples and document them

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ var result = await mediator.Send(new AddTodo("Write docs"));
 await mediator.Publish(new TodoAdded(result.Id));
 ```
 
+## Samples
+
+Clone the repository and run the sample projects to see the mediator in action with real request and notification types.
+
+| Sample | Demonstrates | Run it |
+| --- | --- | --- |
+| **ManualBuilderSample** | Building an `IMediator` instance manually and registering handlers without DI. | `dotnet run --project samples/ManualBuilderSample` |
+| **DependencyInjectionSample** | Wiring handlers with `IServiceCollection` and requesting `IMediator` from the container. | `dotnet run --project samples/DependencyInjectionSample` |
+
+Each sample writes its output to the console so you can verify handler execution.
+
 ## Release flow
 
 - **Stable** – Tag the desired commit with the semantic version (for example `1.2.3`) and push the tag to publish the exact build.

--- a/samples/DependencyInjectionSample/DependencyInjectionSample.csproj
+++ b/samples/DependencyInjectionSample/DependencyInjectionSample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Liaison.Mediator/Liaison.Mediator.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/samples/DependencyInjectionSample/Program.cs
+++ b/samples/DependencyInjectionSample/Program.cs
@@ -1,0 +1,55 @@
+using Liaison.Mediator;
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+
+services.AddMediator(typeof(AddTodoHandler).Assembly);
+services.AddSingleton<TodoRepository>();
+services.AddScoped<AddTodoHandler>();
+services.AddScoped<TodoAddedHandler>();
+
+await using ServiceProvider provider = services.BuildServiceProvider();
+IMediator mediator = provider.GetRequiredService<IMediator>();
+
+Todo todo = await mediator.Send(new AddTodo("Ship the release"));
+await mediator.Publish(new TodoAdded(todo.Id, todo.Title));
+
+public sealed record AddTodo(string Title) : IRequest<Todo>;
+
+public sealed record Todo(int Id, string Title);
+
+public sealed class AddTodoHandler : IRequestHandler<AddTodo, Todo>
+{
+    private readonly TodoRepository _repository;
+
+    public AddTodoHandler(TodoRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<Todo> Handle(AddTodo request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_repository.Create(request.Title));
+    }
+}
+
+public sealed record TodoAdded(int Id, string Title) : INotification;
+
+public sealed class TodoAddedHandler : INotificationHandler<TodoAdded>
+{
+    public Task Handle(TodoAdded notification, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"Observed todo #{notification.Id}: {notification.Title}");
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class TodoRepository
+{
+    private int _nextId = 1;
+
+    public Todo Create(string title)
+    {
+        return new Todo(_nextId++, title);
+    }
+}

--- a/samples/ManualBuilderSample/ManualBuilderSample.csproj
+++ b/samples/ManualBuilderSample/ManualBuilderSample.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Liaison.Mediator/Liaison.Mediator.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/ManualBuilderSample/Program.cs
+++ b/samples/ManualBuilderSample/Program.cs
@@ -1,0 +1,39 @@
+using Liaison.Mediator;
+
+var builder = new MediatorBuilder();
+
+builder.AddRequestHandler<AddTodo, Todo>(new AddTodoHandler())
+       .AddNotificationHandler<TodoAdded>(new TodoAddedHandler());
+
+IMediator mediator = builder.Build();
+
+Todo todo = await mediator.Send(new AddTodo("Write more docs"));
+await mediator.Publish(new TodoAdded(todo.Id, todo.Title));
+
+Console.WriteLine($"Created todo #{todo.Id}: {todo.Title}");
+
+public sealed record AddTodo(string Title) : IRequest<Todo>;
+
+public sealed record Todo(int Id, string Title);
+
+public sealed class AddTodoHandler : IRequestHandler<AddTodo, Todo>
+{
+    private int _nextId = 1;
+
+    public Task<Todo> Handle(AddTodo request, CancellationToken cancellationToken)
+    {
+        var todo = new Todo(_nextId++, request.Title);
+        return Task.FromResult(todo);
+    }
+}
+
+public sealed record TodoAdded(int Id, string Title) : INotification;
+
+public sealed class TodoAddedHandler : INotificationHandler<TodoAdded>
+{
+    public Task Handle(TodoAdded notification, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"Observed todo #{notification.Id}: {notification.Title}");
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add runnable manual builder and dependency injection samples that demonstrate common mediator workflows
- document how to run the samples from the repository README

## Testing
- dotnet build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911246a984c832782eb6cf8eaa67898)