### PR TITLE
[major] DI-backed mediator + notification publisher; multi-target net9/net10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
   "name": "dotnet dev",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "9.0",
-      "additionalVersions": "8.0"
+      "version": "10.0",
+      "additionalVersions": "9.0, 8.0"
     }
   },
   "postCreateCommand": "dotnet --info"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore Liaison.Mediator.sln

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }        # we need tags
       - uses: actions/setup-dotnet@v4
-        with: { dotnet-version: '8.0.x' }
+        with: { dotnet-version: '10.0.x' }
 
       - name: Compute SemVer
         id: v

--- a/samples/DependencyInjectionSample/Program.cs
+++ b/samples/DependencyInjectionSample/Program.cs
@@ -3,10 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 var services = new ServiceCollection();
 
-services.AddMediator(typeof(AddTodoHandler).Assembly);
 services.AddSingleton<TodoRepository>();
-services.AddScoped<AddTodoHandler>();
-services.AddScoped<TodoAddedHandler>();
+services.AddScoped<IRequestHandler<AddTodo, Todo>, AddTodoHandler>();
+services.AddScoped<INotificationHandler<TodoAdded>, TodoAddedHandler>();
+services.AddMediator();
 
 await using ServiceProvider provider = services.BuildServiceProvider();
 IMediator mediator = provider.GetRequiredService<IMediator>();
@@ -40,6 +40,7 @@ public sealed class TodoAddedHandler : INotificationHandler<TodoAdded>
     public Task Handle(TodoAdded notification, CancellationToken cancellationToken)
     {
         Console.WriteLine($"Observed todo #{notification.Id}: {notification.Title}");
+
         return Task.CompletedTask;
     }
 }

--- a/samples/ManualBuilderSample/Program.cs
+++ b/samples/ManualBuilderSample/Program.cs
@@ -2,8 +2,8 @@ using Liaison.Mediator;
 
 var builder = new MediatorBuilder();
 
-builder.AddRequestHandler<AddTodo, Todo>(new AddTodoHandler())
-       .AddNotificationHandler<TodoAdded>(new TodoAddedHandler());
+builder.RegisterRequestHandler<AddTodo, Todo>(new AddTodoHandler())
+       .RegisterNotificationHandler<TodoAdded>(new TodoAddedHandler());
 
 IMediator mediator = builder.Build();
 
@@ -23,6 +23,7 @@ public sealed class AddTodoHandler : IRequestHandler<AddTodo, Todo>
     public Task<Todo> Handle(AddTodo request, CancellationToken cancellationToken)
     {
         var todo = new Todo(_nextId++, request.Title);
+
         return Task.FromResult(todo);
     }
 }
@@ -34,6 +35,7 @@ public sealed class TodoAddedHandler : INotificationHandler<TodoAdded>
     public Task Handle(TodoAdded notification, CancellationToken cancellationToken)
     {
         Console.WriteLine($"Observed todo #{notification.Id}: {notification.Title}");
+
         return Task.CompletedTask;
     }
 }

--- a/src/Liaison.Mediator/ForeachAwaitNotificationPublisher.cs
+++ b/src/Liaison.Mediator/ForeachAwaitNotificationPublisher.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Liaison.Mediator;
+
+/// <summary>
+/// Publishes notifications by awaiting each handler sequentially.
+/// </summary>
+public sealed class ForeachAwaitNotificationPublisher : INotificationPublisher
+{
+    /// <inheritdoc />
+    public async Task Publish(
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors,
+        INotification notification,
+        CancellationToken cancellationToken)
+    {
+        if (handlerExecutors is null)
+        {
+            throw new ArgumentNullException(nameof(handlerExecutors));
+        }
+
+        if (notification is null)
+        {
+            throw new ArgumentNullException(nameof(notification));
+        }
+
+        foreach (var executor in handlerExecutors)
+        {
+            await executor.HandlerCallback(notification, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+

--- a/src/Liaison.Mediator/INotificationPublisher.cs
+++ b/src/Liaison.Mediator/INotificationPublisher.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Liaison.Mediator;
+
+/// <summary>
+/// Defines how notification handlers are invoked when a notification is published.
+/// </summary>
+public interface INotificationPublisher
+{
+    /// <summary>
+    /// Publishes a notification to the provided handler callbacks.
+    /// </summary>
+    /// <param name="handlerExecutors">Handler instances and their callbacks.</param>
+    /// <param name="notification">The notification instance.</param>
+    /// <param name="cancellationToken">Token used to observe cancellation.</param>
+    Task Publish(
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors,
+        INotification notification,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents a notification handler instance and a callback used to invoke it.
+/// </summary>
+public readonly struct NotificationHandlerExecutor
+{
+    /// <summary>
+    /// Creates a new executor.
+    /// </summary>
+    /// <param name="handlerInstance">The handler instance.</param>
+    /// <param name="handlerCallback">Callback that invokes the handler.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="handlerInstance"/> or <paramref name="handlerCallback"/> is <see langword="null"/>.</exception>
+    public NotificationHandlerExecutor(object handlerInstance, Func<INotification, CancellationToken, Task> handlerCallback)
+    {
+        HandlerInstance = handlerInstance ?? throw new ArgumentNullException(nameof(handlerInstance));
+        HandlerCallback = handlerCallback ?? throw new ArgumentNullException(nameof(handlerCallback));
+    }
+
+    /// <summary>
+    /// The handler instance.
+    /// </summary>
+    public object HandlerInstance { get; }
+
+    /// <summary>
+    /// Callback that invokes the handler.
+    /// </summary>
+    public Func<INotification, CancellationToken, Task> HandlerCallback { get; }
+}
+

--- a/src/Liaison.Mediator/IPipelineBehavior.cs
+++ b/src/Liaison.Mediator/IPipelineBehavior.cs
@@ -24,5 +24,4 @@ public interface IPipelineBehavior<TRequest, TResponse>
 /// Delegate representing the continuation to the next behavior or the request handler.
 /// </summary>
 /// <typeparam name="TResponse">Type of the response produced by the handler.</typeparam>
-/// <param name="cancellationToken">Token used to observe cancellation.</param>
-public delegate Task<TResponse> RequestHandlerDelegate<TResponse>(CancellationToken cancellationToken);
+public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();

--- a/src/Liaison.Mediator/Liaison.Mediator.csproj
+++ b/src/Liaison.Mediator/Liaison.Mediator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/Liaison.Mediator/MediatorBuilder.cs
+++ b/src/Liaison.Mediator/MediatorBuilder.cs
@@ -38,6 +38,7 @@ public sealed class MediatorBuilder
         }
 
         _requestHandlers[requestType] = new RequestHandlerWrapper<TRequest, TResponse>(handler);
+
         return this;
     }
 
@@ -63,6 +64,7 @@ public sealed class MediatorBuilder
         }
 
         handlers.Add(new NotificationHandlerWrapper<TNotification>(handler));
+
         return this;
     }
 
@@ -89,6 +91,7 @@ public sealed class MediatorBuilder
         }
 
         behaviors.Add(new PipelineBehaviorWrapper<TRequest, TResponse>(behavior));
+
         return this;
     }
 
@@ -126,6 +129,7 @@ public sealed class MediatorBuilder
             }
 
             var response = await _handler.Handle(typedRequest, cancellationToken).ConfigureAwait(false);
+
             return response;
         }
     }
@@ -168,9 +172,9 @@ public sealed class MediatorBuilder
                 throw new ArgumentException($"Request must be of type {typeof(TRequest)}.", nameof(request));
             }
 
-            async Task<TResponse> TypedNext(CancellationToken ct)
+            async Task<TResponse> TypedNext()
             {
-                var response = await next(ct).ConfigureAwait(false);
+                var response = await next(cancellationToken).ConfigureAwait(false);
                 if (response is null)
                 {
                     if (default(TResponse) is null)
@@ -186,6 +190,7 @@ public sealed class MediatorBuilder
             }
 
             var result = await _behavior.Handle(typedRequest, TypedNext, cancellationToken).ConfigureAwait(false);
+
             return result;
         }
     }

--- a/src/Liaison.Mediator/MediatorServiceCollectionExtensions.cs
+++ b/src/Liaison.Mediator/MediatorServiceCollectionExtensions.cs
@@ -3,24 +3,50 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Liaison.Mediator;
-using Liaison.Mediator.DependencyInjection;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering mediator components with <see cref="IServiceCollection"/>.
+/// </summary>
+public static class MediatorServiceCollectionExtensions
 {
     /// <summary>
-    /// Extension methods for registering mediator components with <see cref="IServiceCollection"/>.
+    /// Registers the mediator with the service collection.
+    /// Handlers and pipeline behaviors must already be registered in the container.
     /// </summary>
-    public static class MediatorServiceCollectionExtensions
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The configured service collection.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+    public static IServiceCollection AddMediator(this IServiceCollection services)
     {
-        /// <summary>
-        /// Registers mediator components located in the provided assemblies.
-        /// </summary>
-        /// <param name="services">The service collection to configure.</param>
-        /// <param name="assemblies">Assemblies that contain mediator handlers or pipeline behaviors.</param>
-        /// <returns>The configured service collection.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="assemblies"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="assemblies"/> does not contain any items.</exception>
-        public static IServiceCollection AddMediator(this IServiceCollection services, params Assembly[] assemblies)
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (!services.Any(static descriptor => descriptor.ServiceType == typeof(INotificationPublisher)))
+        {
+            services.AddSingleton<INotificationPublisher, ForeachAwaitNotificationPublisher>();
+        }
+
+        if (!services.Any(static descriptor => descriptor.ServiceType == typeof(IMediator)))
+        {
+            services.AddScoped<IMediator, ServiceProviderMediator>();
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers mediator handlers and pipeline behaviors located in the provided assemblies.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="assemblies">Assemblies that contain mediator handlers or pipeline behaviors.</param>
+    /// <returns>The configured service collection.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="assemblies"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="assemblies"/> does not contain any items.</exception>
+    public static IServiceCollection AddMediator(this IServiceCollection services, params Assembly[] assemblies)
     {
         if (services is null)
         {
@@ -45,27 +71,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
         RegisterHandlers(services, distinctAssemblies);
 
-        services.AddScoped<IMediator>(provider =>
-        {
-            var builder = new MediatorBuilder();
-
-            foreach (var registration in provider.GetServices<IMediatorRegistration>())
-            {
-                registration.Register(builder);
-            }
-
-            return builder.Build();
-        });
-
-        return services;
+        return services.AddMediator();
     }
 
     private static void RegisterHandlers(IServiceCollection services, IReadOnlyCollection<Assembly> assemblies)
     {
-        var requestRegistrations = new HashSet<Type>();
-        var notificationRegistrations = new HashSet<Type>();
-        var pipelineRegistrations = new HashSet<Type>();
-
         foreach (var assembly in assemblies)
         {
             foreach (var type in GetDefinedTypes(assembly))
@@ -88,38 +98,16 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
 
                     var interfaceType = implementedInterface.GetGenericTypeDefinition();
-                    var genericArguments = implementedInterface.GetGenericArguments();
+                    if (interfaceType != typeof(IRequestHandler<,>) &&
+                        interfaceType != typeof(INotificationHandler<>) &&
+                        interfaceType != typeof(IPipelineBehavior<,>))
+                    {
+                        continue;
+                    }
 
-                    if (interfaceType == typeof(IRequestHandler<,>))
-                    {
-                        services.AddTransient(implementedInterface, type.AsType());
-                        RegisterMediatorDescriptor(services, requestRegistrations, typeof(RequestHandlerRegistration<,>), genericArguments);
-                    }
-                    else if (interfaceType == typeof(INotificationHandler<>))
-                    {
-                        services.AddTransient(implementedInterface, type.AsType());
-                        RegisterMediatorDescriptor(services, notificationRegistrations, typeof(NotificationHandlerRegistration<>), genericArguments);
-                    }
-                    else if (interfaceType == typeof(IPipelineBehavior<,>))
-                    {
-                        services.AddTransient(implementedInterface, type.AsType());
-                        RegisterMediatorDescriptor(services, pipelineRegistrations, typeof(PipelineBehaviorRegistration<,>), genericArguments);
-                    }
+                    services.AddTransient(implementedInterface, type.AsType());
                 }
             }
-        }
-    }
-
-    private static void RegisterMediatorDescriptor(
-        IServiceCollection services,
-        ISet<Type> registrationTracker,
-        Type registrationTypeDefinition,
-        IReadOnlyList<Type> genericArguments)
-    {
-        var registrationType = registrationTypeDefinition.MakeGenericType(genericArguments.ToArray());
-        if (registrationTracker.Add(registrationType))
-        {
-            services.AddTransient(typeof(IMediatorRegistration), registrationType);
         }
     }
 
@@ -134,82 +122,4 @@ namespace Microsoft.Extensions.DependencyInjection
             return exception.Types.Where(static type => type is not null).Select(static type => type!.GetTypeInfo());
         }
     }
-    }
-}
-
-namespace Liaison.Mediator.DependencyInjection
-{
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
-internal interface IMediatorRegistration
-{
-    void Register(MediatorBuilder builder);
-}
-
-internal sealed class RequestHandlerRegistration<TRequest, TResponse> : IMediatorRegistration
-    where TRequest : IRequest<TResponse>
-{
-    private readonly IEnumerable<IRequestHandler<TRequest, TResponse>> _handlers;
-
-    public RequestHandlerRegistration(IEnumerable<IRequestHandler<TRequest, TResponse>> handlers)
-    {
-        _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
-    }
-
-    public void Register(MediatorBuilder builder)
-    {
-        var handlers = _handlers.ToArray();
-        if (handlers.Length == 0)
-        {
-            throw new InvalidOperationException($"No handler registered for '{typeof(TRequest).FullName}'.");
-        }
-
-        if (handlers.Length > 1)
-        {
-            throw new InvalidOperationException($"Multiple handlers registered for '{typeof(TRequest).FullName}'.");
-        }
-
-        builder.RegisterRequestHandler<TRequest, TResponse>(handlers[0]);
-    }
-}
-
-internal sealed class NotificationHandlerRegistration<TNotification> : IMediatorRegistration
-    where TNotification : INotification
-{
-    private readonly IEnumerable<INotificationHandler<TNotification>> _handlers;
-
-    public NotificationHandlerRegistration(IEnumerable<INotificationHandler<TNotification>> handlers)
-    {
-        _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
-    }
-
-    public void Register(MediatorBuilder builder)
-    {
-        foreach (var handler in _handlers)
-        {
-            builder.RegisterNotificationHandler(handler);
-        }
-    }
-}
-
-internal sealed class PipelineBehaviorRegistration<TRequest, TResponse> : IMediatorRegistration
-    where TRequest : IRequest<TResponse>
-{
-    private readonly IEnumerable<IPipelineBehavior<TRequest, TResponse>> _behaviors;
-
-    public PipelineBehaviorRegistration(IEnumerable<IPipelineBehavior<TRequest, TResponse>> behaviors)
-    {
-        _behaviors = behaviors ?? throw new ArgumentNullException(nameof(behaviors));
-    }
-
-    public void Register(MediatorBuilder builder)
-    {
-        foreach (var behavior in _behaviors)
-        {
-            builder.RegisterPipelineBehavior(behavior);
-        }
-    }
-}
 }

--- a/src/Liaison.Mediator/NuGetReadme.md
+++ b/src/Liaison.Mediator/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Liaison.Mediator
 
-Liaison.Mediator is a lightweight mediator library that keeps the familiar request/response and notification patterns of MediatR while removing assembly scanning. Register handlers explicitly or opt into dependency injection support via `AddMediator`.
+Liaison.Mediator is a lightweight mediator library that keeps the familiar request/response and notification patterns of MediatR while making handler registration explicit by default. You can also wire it into Microsoft.Extensions.DependencyInjection via `AddMediator`.
 
 ## Installation
 
@@ -15,8 +15,8 @@ Install-Package Liaison.Mediator
 ```csharp
 var builder = new MediatorBuilder();
 
-builder.AddRequestHandler<CreateOrder, Order>(new CreateOrderHandler())
-       .AddNotificationHandler<OrderCreated>(new OrderCreatedHandler());
+builder.RegisterRequestHandler<CreateOrder, Order>(new CreateOrderHandler())
+       .RegisterNotificationHandler<OrderCreated>(new OrderCreatedHandler());
 
 IMediator mediator = builder.Build();
 ```
@@ -25,7 +25,9 @@ IMediator mediator = builder.Build();
 
 ```csharp
 var services = new ServiceCollection();
-services.AddMediator(typeof(CreateOrderHandler).Assembly);
+services.AddScoped<IRequestHandler<CreateOrder, Order>, CreateOrderHandler>();
+services.AddScoped<INotificationHandler<OrderCreated>, OrderCreatedHandler>();
+services.AddMediator();
 
 await using ServiceProvider provider = services.BuildServiceProvider();
 IMediator mediator = provider.GetRequiredService<IMediator>();

--- a/src/Liaison.Mediator/ServiceProviderMediator.cs
+++ b/src/Liaison.Mediator/ServiceProviderMediator.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Liaison.Mediator;
+
+internal sealed class ServiceProviderMediator : IMediator
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly INotificationPublisher _notificationPublisher;
+    private readonly ConcurrentDictionary<Type, IRequestHandlerWrapper> _requestHandlerWrappers = new();
+    private readonly ConcurrentDictionary<Type, INotificationHandlerWrapper> _notificationHandlerWrappers = new();
+
+    public ServiceProviderMediator(IServiceProvider serviceProvider, INotificationPublisher notificationPublisher)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _notificationPublisher = notificationPublisher ?? throw new ArgumentNullException(nameof(notificationPublisher));
+    }
+
+    public async Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var requestType = request.GetType();
+        var wrapper = _requestHandlerWrappers.GetOrAdd(requestType, CreateRequestHandlerWrapper);
+        var response = await wrapper.Handle(request, cancellationToken).ConfigureAwait(false);
+
+        if (response is null)
+        {
+            if (default(TResponse) is null)
+            {
+                return default!;
+            }
+
+            throw new InvalidOperationException(
+                $"The handler for request type '{requestType.FullName}' returned null but '{typeof(TResponse).FullName}' is not nullable.");
+        }
+
+        if (response is TResponse typedResponse)
+        {
+            return typedResponse;
+        }
+
+        throw new InvalidOperationException(
+            $"Handler registered for '{requestType.FullName}' returned '{response.GetType().FullName}' which cannot be cast to '{typeof(TResponse).FullName}'.");
+    }
+
+    public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+        where TNotification : INotification
+    {
+        if (notification is null)
+        {
+            throw new ArgumentNullException(nameof(notification));
+        }
+
+        var notificationType = notification.GetType();
+        var wrapper = _notificationHandlerWrappers.GetOrAdd(notificationType, CreateNotificationHandlerWrapper);
+
+        return wrapper.Handle(notification, cancellationToken);
+    }
+
+    private IRequestHandlerWrapper CreateRequestHandlerWrapper(Type requestType)
+    {
+        var requestInterface = requestType
+            .GetTypeInfo()
+            .ImplementedInterfaces
+            .Where(static candidate => candidate.IsGenericType)
+            .Where(static candidate => candidate.GetGenericTypeDefinition() == typeof(IRequest<>))
+            .Select(static candidate => new
+            {
+                RequestInterface = candidate,
+                ResponseType = candidate.GetGenericArguments()[0],
+            })
+            .FirstOrDefault();
+
+        if (requestInterface is null)
+        {
+            throw new InvalidOperationException($"Request type '{requestType.FullName}' does not implement '{typeof(IRequest<>).FullName}'.");
+        }
+
+        var wrapperType = typeof(ServiceProviderRequestHandlerWrapper<,>).MakeGenericType(requestType, requestInterface.ResponseType);
+
+        return (IRequestHandlerWrapper)Activator.CreateInstance(wrapperType, _serviceProvider)!;
+    }
+
+    private INotificationHandlerWrapper CreateNotificationHandlerWrapper(Type notificationType)
+    {
+        var wrapperType = typeof(ServiceProviderNotificationHandlerWrapper<>).MakeGenericType(notificationType);
+
+        return (INotificationHandlerWrapper)Activator.CreateInstance(wrapperType, _serviceProvider, _notificationPublisher)!;
+    }
+
+    private sealed class ServiceProviderRequestHandlerWrapper<TRequest, TResponse> : IRequestHandlerWrapper
+        where TRequest : IRequest<TResponse>
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ServiceProviderRequestHandlerWrapper(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
+        public async Task<object?> Handle(object request, CancellationToken cancellationToken)
+        {
+            if (request is not TRequest typedRequest)
+            {
+                throw new ArgumentException($"Request must be of type {typeof(TRequest)}.", nameof(request));
+            }
+
+            var handlers = _serviceProvider.GetServices<IRequestHandler<TRequest, TResponse>>().ToArray();
+            if (handlers.Length == 0)
+            {
+                throw new InvalidOperationException($"No handler registered for request type '{typeof(TRequest).FullName}'.");
+            }
+
+            if (handlers.Length > 1)
+            {
+                throw new InvalidOperationException($"Multiple handlers registered for request type '{typeof(TRequest).FullName}'.");
+            }
+
+            var handler = handlers[0];
+            var behaviors = _serviceProvider.GetServices<IPipelineBehavior<TRequest, TResponse>>().ToArray();
+
+            RequestHandlerDelegate<TResponse> next = () => handler.Handle(typedRequest, cancellationToken);
+
+            for (var i = behaviors.Length - 1; i >= 0; i--)
+            {
+                var behavior = behaviors[i];
+                var continuation = next;
+                next = () => behavior.Handle(typedRequest, continuation, cancellationToken);
+            }
+
+            var response = await next().ConfigureAwait(false);
+
+            return response;
+        }
+    }
+
+    private sealed class ServiceProviderNotificationHandlerWrapper<TNotification> : INotificationHandlerWrapper
+        where TNotification : INotification
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly INotificationPublisher _notificationPublisher;
+
+        public ServiceProviderNotificationHandlerWrapper(IServiceProvider serviceProvider, INotificationPublisher notificationPublisher)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _notificationPublisher = notificationPublisher ?? throw new ArgumentNullException(nameof(notificationPublisher));
+        }
+
+        public Task Handle(object notification, CancellationToken cancellationToken)
+        {
+            if (notification is not TNotification typedNotification)
+            {
+                throw new ArgumentException($"Notification must be of type {typeof(TNotification)}.", nameof(notification));
+            }
+
+            var handlers = _serviceProvider.GetServices<INotificationHandler<TNotification>>().ToArray();
+            if (handlers.Length == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            var executors = handlers.Select(handler =>
+                new NotificationHandlerExecutor(
+                    handler,
+                    (not, ct) => handler.Handle((TNotification)not, ct)));
+
+            return _notificationPublisher.Publish(executors, typedNotification, cancellationToken);
+        }
+    }
+}

--- a/src/Liaison.Mediator/TaskWhenAllNotificationPublisher.cs
+++ b/src/Liaison.Mediator/TaskWhenAllNotificationPublisher.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Liaison.Mediator;
+
+/// <summary>
+/// Publishes notifications by running all handlers concurrently and awaiting completion.
+/// </summary>
+public sealed class TaskWhenAllNotificationPublisher : INotificationPublisher
+{
+    /// <inheritdoc />
+    public Task Publish(
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors,
+        INotification notification,
+        CancellationToken cancellationToken)
+    {
+        if (handlerExecutors is null)
+        {
+            throw new ArgumentNullException(nameof(handlerExecutors));
+        }
+
+        if (notification is null)
+        {
+            throw new ArgumentNullException(nameof(notification));
+        }
+
+        var tasks = new List<Task>();
+        foreach (var executor in handlerExecutors)
+        {
+            tasks.Add(executor.HandlerCallback(notification, cancellationToken));
+        }
+
+        return Task.WhenAll(tasks);
+    }
+}
+

--- a/tests/Liaison.Mediator.Tests/Liaison.Mediator.Tests.csproj
+++ b/tests/Liaison.Mediator.Tests/Liaison.Mediator.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Liaison.Mediator.Tests/MediatorBuilderTests.cs
+++ b/tests/Liaison.Mediator.Tests/MediatorBuilderTests.cs
@@ -131,6 +131,7 @@ public class MediatorBuilderTests
             {
                 Invoked = true;
                 _steps?.Add("handler");
+
                 return Task.FromResult($"{request.Message} pong");
             }
         }
@@ -147,6 +148,7 @@ public class MediatorBuilderTests
         public Task Handle(TestNotification notification, CancellationToken cancellationToken)
         {
             _notifications.Add(notification);
+
             return Task.CompletedTask;
         }
     }
@@ -160,6 +162,7 @@ public class MediatorBuilderTests
             public Task<Unit> Handle(VoidRequest request, CancellationToken cancellationToken)
             {
                 Invoked = true;
+
                 return Task.FromResult(Unit.Value);
             }
         }
@@ -182,8 +185,9 @@ public class MediatorBuilderTests
             CancellationToken cancellationToken)
         {
             _steps.Add($"{_name} before");
-            var response = await next(cancellationToken).ConfigureAwait(false);
+            var response = await next().ConfigureAwait(false);
             _steps.Add($"{_name} after");
+
             return response;
         }
     }


### PR DESCRIPTION
## Summary
- Introduce a DI-backed IMediator implementation (ServiceProviderMediator) for explicit, non-scanning registration.
- Add INotificationPublisher with sequential (ForeachAwaitNotificationPublisher) and parallel (TaskWhenAllNotificationPublisher) strategies.
- Align pipeline delegate signature with MediatR (RequestHandlerDelegate<TResponse> is parameterless).
- Multi-target netstandard2.0;net8.0;net9.0;net10.0 and update CI/devcontainer for .NET 10.
- Refresh test dependencies (Microsoft.NET.Test.Sdk, xUnit, coverlet).

## Breaking changes
- RequestHandlerDelegate<TResponse> is now parameterless.
- AddMediator() no longer scans assemblies; handlers/pipeline behaviors must be registered explicitly (assembly-scanning overload remains).

## Testing
- dotnet test -c Release
