### PR TITLE
test: target net10.0

### DIFF
--- a/tests/Liaison.Mediator.Tests/Liaison.Mediator.Tests.csproj
+++ b/tests/Liaison.Mediator.Tests/Liaison.Mediator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Updates the test project to target .NET 10 (`net10.0`) to match the repo's CI/build toolchain.

Release note: after merging, tag the merge commit with `1.0.0` to publish the stable package (publish workflow triggers stable builds on `X.Y.Z` tags).
